### PR TITLE
feat(Request): add verbosity option

### DIFF
--- a/examples/BasicExample.re
+++ b/examples/BasicExample.re
@@ -4,7 +4,9 @@ module Log = (val Timber.Log.withNamespace("ReQuests.BasicExample"));
 
 let () = {
   Timber.App.enable(Timber.Reporter.console(~enableColors=true, ()));
+  Timber.App.setLevel(Timber.Level.debug);
   ReQuests.init();
+
   let onResponse = (response: Response.t) =>
     switch (response) {
     | Ok(response) =>
@@ -35,6 +37,7 @@ let () = {
     ~onResponse,
     Request.make(
       ~headers=["Client: ReQuests"],
+      ~verbose=true,
       "https://httpbin.org/headers",
     ),
   );

--- a/src/ReQuests.rei
+++ b/src/ReQuests.rei
@@ -50,6 +50,7 @@ module Request: {
       ~proxy: Proxy.t=?,
       ~timeout: int=?,
       ~caCertPath: string=?,
+      ~verbose: bool=?,
       string
     ) =>
     t;


### PR DESCRIPTION
This hooks into cURL's `set_debugfunction` and `set_verbose` to get a debug print-out of requests.

This is useful for something like getting SSL certificate data:
```
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] ⭠ SSL DATA IN
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT: TLSv1.2 (IN), TLS handshake, Finished (20):
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] ⭠ SSL DATA IN
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT: SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT: ALPN, server accepted to use h2
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT: Server certificate:
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT:  subject: CN=httpbin.org
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT:  start date: Dec 21 00:00:00 2020 GMT
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT:  expire date: Jan 19 23:59:59 2022 GMT
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT:  subjectAltName: host "httpbin.org" matched cert's "httpbin.org"
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT:  issuer: C=US; O=Amazon; OU=Server CA 1B; CN=Amazon
[DEBUG] [ 0.082s] ReQuests.Request : Request[2, https://httpbin.org/headers] TEXT:  SSL certificate verify ok.
```